### PR TITLE
Fix error handling incompatible with Python 3

### DIFF
--- a/source/code/boto_retry/aws_service_retry.py
+++ b/source/code/boto_retry/aws_service_retry.py
@@ -49,7 +49,9 @@ class AwsApiServiceRetry:
         :param ex:
         :return:
         """
-        return "throttling" in ex.message.lower()
+        return type(ex) == ClientError and \
+               ex.response.get("ResponseMetadata", {}).get("HTTPStatusCode", 0) == 400 and \
+               "throttl" in ex.response.get("Error", {}).get("Code", "").lower()
 
     @classmethod
     def service_not_available(cls, ex):


### PR DESCRIPTION
This takes into account different types of throttling e.g.
Throttling
ThrottlingException
ThrottledException
RequestThrottledException

*Issue #, if available:* #133 

*Description of changes:*
Apply error handling pattern from `Ec2ServiceRetry` to `AwsApiServiceRetry`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
