### PR TITLE
GovCloud Intergration

### DIFF
--- a/source/cloudformation/instance-scheduler-remote.template
+++ b/source/cloudformation/instance-scheduler-remote.template
@@ -11,14 +11,16 @@
     },
     "Metadata": {
         "AWS::CloudFormation::Interface": {
-            "ParameterGroups": [{
-                "Label": {
-                    "default": "Account"
-                },
-                "Parameters": [
-                    "InstanceSchedulerAccount"
-                ]
-            }],
+            "ParameterGroups": [
+                {
+                    "Label": {
+                        "default": "Account"
+                    },
+                    "Parameters": [
+                        "InstanceSchedulerAccount"
+                    ]
+                }
+            ],
             "ParameterLabels": {
                 "InstanceSchedulerAccount": {
                     "default": "Primary account"
@@ -42,25 +44,33 @@
             "Properties": {
                 "AssumeRolePolicyDocument": {
                     "Version": "2012-10-17",
-                    "Statement": [{
-                        "Effect": "Allow",
-                        "Principal": {
-                            "AWS": {
-                                "Fn::Join": [
-                                    "", [
-                                        "arn:aws:iam::", {
-                                            "Ref": "InstanceSchedulerAccount"
-                                        },
-                                        ":root"
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "AWS": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "arn:",
+                                            {
+                                                "Ref": "AWS::Partition"
+                                            },
+                                            ":iam::",
+                                            {
+                                                "Ref": "InstanceSchedulerAccount"
+                                            },
+                                            ":root"
+                                        ]
                                     ]
-                                ]
+                                },
+                                "Service": "lambda.amazonaws.com"
                             },
-                            "Service": "lambda.amazonaws.com"
-                        },
-                        "Action": [
-                            "sts:AssumeRole"
-                        ]
-                    }]
+                            "Action": [
+                                "sts:AssumeRole"
+                            ]
+                        }
+                    ]	  
                 },
                 "Path": "/",
                 "Policies": [
@@ -80,7 +90,11 @@
                                         "Fn::Join": [
                                             ":",
                                             [
-                                                "arn:aws:rds:*",
+                                                "arn",
+                                                {
+                                                    "Ref": "AWS::Partition"
+                                                },
+                                                "rds:*",
                                                 {
                                                     "Ref": "AWS::AccountId"
                                                 },
@@ -102,7 +116,11 @@
                                         "Fn::Join": [
                                             ":",
                                             [
-                                                "arn:aws:rds:*",
+                                                "arn",
+                                                {
+                                                    "Ref": "AWS::Partition"
+                                                },
+                                                "rds:*",
                                                 {
                                                     "Ref": "AWS::AccountId"
                                                 },
@@ -124,7 +142,11 @@
                                             "Fn::Join": [
                                                 ":",
                                                 [
-                                                    "arn:aws:rds:*",
+                                                    "arn",
+                                                    {
+                                                        "Ref": "AWS::Partition"
+                                                    },
+                                                    "rds:*",
                                                     {
                                                         "Ref": "AWS::AccountId"
                                                     },
@@ -147,7 +169,11 @@
                                             "Fn::Join": [
                                                 ":",
                                                 [
-                                                    "arn:aws:ec2:*",
+                                                    "arn",
+                                                    {
+                                                        "Ref": "AWS::Partition"
+                                                    },
+                                                    "ec2:*",
                                                     {
                                                         "Ref": "AWS::AccountId"
                                                     },
@@ -165,10 +191,8 @@
                                         "ec2:DescribeInstances",
                                         "ec2:DescribeRegions",
                                         "ec2:ModifyInstanceAttribute",
-
                                         "ssm:DescribeMaintenanceWindows",
                                         "ssm:DescribeMaintenanceWindowExecutions",
-
                                         "tag:GetResources"
                                     ],
                                     "Resource": [

--- a/source/cloudformation/instance-scheduler.template
+++ b/source/cloudformation/instance-scheduler.template
@@ -815,7 +815,7 @@
                 }
             },
             "Properties": {
-                 "PolicyName": "EC2DynamoDBPolicy",
+                "PolicyName": "EC2DynamoDBPolicy",
                 "Roles": [
                     {
                         "Ref": "SchedulerRole"
@@ -824,7 +824,7 @@
                 "PolicyDocument": {
                     "Version": "2012-10-17",
                     "Statement": [
-                       {
+                        {
                             "Effect": "Allow",
                             "Action": [
                                 "dynamodb:DeleteItem",
@@ -843,7 +843,11 @@
                                                 "Fn::Join": [
                                                     ":",
                                                     [
-                                                        "arn:aws:dynamodb",
+                                                        "arn",
+                                                        {
+                                                            "Ref": "AWS::Partition"
+                                                        },
+                                                        "dynamodb",
                                                         {
                                                             "Ref": "AWS::Region"
                                                         },
@@ -868,7 +872,11 @@
                                                 "Fn::Join": [
                                                     ":",
                                                     [
-                                                        "arn:aws:dynamodb",
+                                                        "arn",
+                                                        {
+                                                            "Ref": "AWS::Partition"
+                                                        },
+                                                        "dynamodb",
                                                         {
                                                             "Ref": "AWS::Region"
                                                         },
@@ -893,7 +901,11 @@
                                                 "Fn::Join": [
                                                     ":",
                                                     [
-                                                        "arn:aws:dynamodb",
+                                                        "arn",
+                                                        {
+                                                            "Ref": "AWS::Partition"
+                                                        },
+                                                        "dynamodb",
                                                         {
                                                             "Ref": "AWS::Region"
                                                         },
@@ -925,7 +937,11 @@
                                     "Fn::Join": [
                                         ":",
                                         [
-                                            "arn:aws:logs",
+                                            "arn",
+                                            {
+                                                "Ref": "AWS::Partition"
+                                            },
+                                            "logs",
                                             {
                                                 "Ref": "AWS::Region"
                                             },
@@ -944,7 +960,11 @@
                                     "Fn::Join": [
                                         ":",
                                         [
-                                            "arn:aws:logs",
+                                            "arn",
+                                            {
+                                                "Ref": "AWS::Partition"
+                                            },
+                                            "logs",
                                             {
                                                 "Ref": "AWS::Region"
                                             },
@@ -979,9 +999,18 @@
                             "Action": [
                                 "sts:AssumeRole"
                             ],
-                            "Resource": [
-                                "arn:aws:iam::*:role/*EC2SchedulerCross*"
-                            ]
+                            "Resource": {
+                                "Fn::Join": [
+                                    ":",
+                                    [
+                                        "arn",
+                                        {
+                                            "Ref": "AWS::Partition"
+                                        },
+                                        "iam::*:role/*EC2SchedulerCross*"
+                                    ]
+                                ]
+                            }
                         },
                         {
                             "Effect": "Allow",
@@ -993,7 +1022,11 @@
                                 "Fn::Join": [
                                     ":",
                                     [
-                                        "arn:aws:ssm:*",
+                                        "arn",
+                                        {
+                                            "Ref": "AWS::Partition"
+                                        },
+                                        "ssm:*",
                                         {
                                             "Ref": "AWS::AccountId"
                                         },
@@ -1039,7 +1072,11 @@
                                 "Fn::Join": [
                                     ":",
                                     [
-                                        "arn:aws:rds:*",
+                                        "arn",
+                                        {
+                                            "Ref": "AWS::Partition"
+                                        },
+                                        "rds:*",
                                         {
                                             "Ref": "AWS::AccountId"
                                         },
@@ -1061,7 +1098,11 @@
                                 "Fn::Join": [
                                     ":",
                                     [
-                                        "arn:aws:rds:*",
+                                        "arn",
+                                        {
+                                            "Ref": "AWS::Partition"
+                                        },
+                                        "rds:*",
                                         {
                                             "Ref": "AWS::AccountId"
                                         },
@@ -1083,7 +1124,11 @@
                                     "Fn::Join": [
                                         ":",
                                         [
-                                            "arn:aws:rds:*",
+                                            "arn",
+                                            {
+                                                "Ref": "AWS::Partition"
+                                            },
+                                            "rds:*",
                                             {
                                                 "Ref": "AWS::AccountId"
                                             },
@@ -1106,7 +1151,11 @@
                                     "Fn::Join": [
                                         ":",
                                         [
-                                            "arn:aws:ec2:*",
+                                            "arn",
+                                            {
+                                                "Ref": "AWS::Partition"
+                                            },
+                                            "ec2:*",
                                             {
                                                 "Ref": "AWS::AccountId"
                                             },
@@ -1135,7 +1184,11 @@
                                     "Fn::Join": [
                                         ":",
                                         [
-                                            "arn:aws:lambda",
+                                            "arn",
+                                            {
+                                                "Ref": "AWS::Partition"
+                                            },
+                                            "lambda",
                                             {
                                                 "Ref": "AWS::Region"
                                             },
@@ -1472,7 +1525,11 @@
                     "Fn::Join": [
                         ":",
                         [
-                            "arn:aws:lambda",
+                            "arn",
+                            {
+                                "Ref": "AWS::Partition"
+                            },
+                            "lambda",
                             {
                                 "Ref": "AWS::Region"
                             },
@@ -1534,7 +1591,11 @@
                             "Fn::Join": [
                                 ":",
                                 [
-                                    "arn:aws:lambda",
+                                    "arn",
+                                    {
+                                        "Ref": "AWS::Partition"
+                                    },
+                                    "lambda",
                                     {
                                         "Ref": "AWS::Region"
                                     },
@@ -1699,4 +1760,3 @@
         }
     }
 }
-


### PR DESCRIPTION
Templates updated for use in both validated standard AWS regions and AWS GovCloud (US) regions via the AWS::Partition parameter. Successful CloudFormation build in both partitions (Regions built in: us-east-1, us-gov-west-1, us-gov-east-1) Used my own buckets for GovCloud build. Attention from solution owners would be needed on the back end since the solution resources are not available in buckets "solutions-us-gov-west-1" and "solutions-us-gov-east-1".

*Issue  11, 105 

*Description of changes:*
Modified principal and policy ARNs to dynamically detect the partition they are in using [AWS::Partition](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/pseudo-parameter-reference.html#cfn-pseudo-param-partition) pseudo parameter.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.