### PR TITLE
Add exports to template

### DIFF
--- a/deployment/instance-scheduler.template
+++ b/deployment/instance-scheduler.template
@@ -1675,7 +1675,7 @@
             "Value": {
                 "Ref": "ConfigTable"
             },
-            "Description": "Name of the DynomoDB configuration table",
+            "Description": "Name of the DynamoDB configuration table",
             "Export" : {
                 "Name" : {
                     "Fn::Sub": "${AWS::StackName}-${AWS::Region}-ConfigurationTable"

--- a/deployment/instance-scheduler.template
+++ b/deployment/instance-scheduler.template
@@ -1664,19 +1664,34 @@
             "Value": {
                 "Ref": "AWS::AccountId"
             },
-            "Description": "Account to give access to when creating cross-account access role fro cross account scenario "
+            "Description": "Account to give access to when creating cross-account access role fro cross account scenario ",
+            "Export" : {
+                "Name" : {
+                    "Fn::Sub": "${AWS::AccountId}"
+                }
+            }              
         },
         "ConfigurationTable": {
             "Value": {
                 "Ref": "ConfigTable"
             },
-            "Description": "Name of the DynomoDB configuration table"
+            "Description": "Name of the DynomoDB configuration table",
+            "Export" : {
+                "Name" : {
+                    "Fn::Sub": "${AWS::StackName}-${AWS::Region}-ConfigurationTable"
+                }
+            }            
         },
         "IssueSnsTopicArn": {
             "Value": {
                 "Ref": "InstanceSchedulerSnsTopic"
             },
-            "Description": "Topic to subscribe to for notifications of errors and warnings"
+            "Description": "Topic to subscribe to for notifications of errors and warnings",
+            "Export" : {
+                "Name" : {
+                    "Fn::Sub": "${AWS::StackName}-${AWS::Region}-IssueSnsTopicArn"
+                }
+            }            
         },
         "SchedulerRoleArn": {
             "Value": {
@@ -1685,7 +1700,12 @@
                     "Arn"
                 ]
             },
-            "Description": "Role for the instance scheduler lambda function"
+            "Description": "Role for the instance scheduler lambda function",
+            "Export" : {
+                "Name" : {
+                    "Fn::Sub": "${AWS::StackName}-${AWS::Region}-SchedulerRoleArn"
+                }
+            }            
         },
         "ServiceInstanceScheduleServiceToken": {
             "Value": {
@@ -1694,7 +1714,12 @@
                     "Arn"
                 ]
             },
-            "Description": "Arn to use as ServiceToken property for custom resource type Custom::ServiceInstanceSchedule"
+            "Description": "Arn to use as ServiceToken property for custom resource type Custom::ServiceInstanceSchedule",
+            "Export" : {
+                "Name" : {
+                    "Fn::Sub": "${AWS::StackName}-${AWS::Region}-ServiceInstanceScheduleServiceToken"
+                }
+            }            
         }
     }
 }

--- a/source/cloudformation/instance-scheduler.template
+++ b/source/cloudformation/instance-scheduler.template
@@ -1665,19 +1665,34 @@
             "Value": {
                 "Ref": "AWS::AccountId"
             },
-            "Description": "Account to give access to when creating cross-account access role fro cross account scenario "
+            "Description": "Account to give access to when creating cross-account access role fro cross account scenario ",
+            "Export" : {
+                "Name" : {
+                    "Fn::Sub": "${AWS::AccountId}"
+                }
+            }              
         },
         "ConfigurationTable": {
             "Value": {
                 "Ref": "ConfigTable"
             },
-            "Description": "Name of the DynomoDB configuration table"
+            "Description": "Name of the DynamoDB configuration table",
+            "Export" : {
+                "Name" : {
+                    "Fn::Sub": "${AWS::StackName}-${AWS::Region}-ConfigurationTable"
+                }
+            }            
         },
         "IssueSnsTopicArn": {
             "Value": {
                 "Ref": "InstanceSchedulerSnsTopic"
             },
-            "Description": "Topic to subscribe to for notifications of errors and warnings"
+            "Description": "Topic to subscribe to for notifications of errors and warnings",
+            "Export" : {
+                "Name" : {
+                    "Fn::Sub": "${AWS::StackName}-${AWS::Region}-IssueSnsTopicArn"
+                }
+            }            
         },
         "SchedulerRoleArn": {
             "Value": {
@@ -1686,7 +1701,12 @@
                     "Arn"
                 ]
             },
-            "Description": "Role for the instance scheduler lambda function"
+            "Description": "Role for the instance scheduler lambda function",
+            "Export" : {
+                "Name" : {
+                    "Fn::Sub": "${AWS::StackName}-${AWS::Region}-SchedulerRoleArn"
+                }
+            }            
         },
         "ServiceInstanceScheduleServiceToken": {
             "Value": {
@@ -1695,7 +1715,12 @@
                     "Arn"
                 ]
             },
-            "Description": "Arn to use as ServiceToken property for custom resource type Custom::ServiceInstanceSchedule"
+            "Description": "Arn to use as ServiceToken property for custom resource type Custom::ServiceInstanceSchedule",
+            "Export" : {
+                "Name" : {
+                    "Fn::Sub": "${AWS::StackName}-${AWS::Region}-ServiceInstanceScheduleServiceToken"
+                }
+            }            
         }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
[Issue 188](https://github.com/awslabs/aws-instance-scheduler/issues/188)

*Description of changes:*

Added exports to the templates so they can be used by custom resource CloudFormation instead of hard-coding the lambda arn: https://docs.aws.amazon.com/solutions/latest/instance-scheduler/appendix-d.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
