### PR TITLE
Add license manager IAM resource to start/stop instances statement

### DIFF
--- a/source/lib/aws-instance-scheduler-remote-stack.ts
+++ b/source/lib/aws-instance-scheduler-remote-stack.ts
@@ -104,7 +104,8 @@ export class AwsInstanceSchedulerRemoteStack extends cdk.Stack {
                             ],
                             effect: Effect.ALLOW,
                             resources: [
-                                cdk.Fn.sub("arn:${AWS::Partition}:ec2:*:${AWS::AccountId}:instance/*")
+                                cdk.Fn.sub("arn:${AWS::Partition}:ec2:*:${AWS::AccountId}:instance/*"),
+                                cdk.Fn.sub("arn:${AWS::Partition}:license-manager:*:${AWS::AccountId}:license-configuration/*")
                             ]
                         }),
                         new PolicyStatement({


### PR DESCRIPTION
*Description of changes:*

When instances are managed by AWS License Manager, the scheduler fails to query the license-configurations API.  This is easily fixed by including the appropriate IAM resource in the `instance-scheduler-remote-stack`.

The specific error received looked like this after decoding the cloudwatch log error sent by SNS.

I have redacted identifying information from this snippet.

```
{
  "allowed": false,
  "explicitDeny": false,
  "matchedStatements": {
    "items": []
  },
  "failures": {
    "items": []
  },
  "context": {
    "principal": {
      "id": "ARO...7DX56:ec2-scheduler-7...0",
      "arn": "arn:aws:sts::7...0:assumed-role/EC2InstanceSchedulerRole/ec2-scheduler-7...0"
    },
    "action": "ec2:StartInstances",
    "resource": "arn:aws:license-manager:ap-southeast-2:7...2:license-configuration:lic-b.................1",
    "conditions": {
      "items": [
        {
          "key": "aws:Region",
          "values": {
            "items": [
              {
                "value": "ap-southeast-2"
              }
            ]
          }
        },
        {
          "key": "aws:ID",
          "values": {
            "items": [
              {
                "value": "lic-b.................1"
              }
            ]
          }
        },
        {
          "key": "aws:Service",
          "values": {
            "items": [
              {
                "value": "ec2"
              }
            ]
          }
        },
        {
          "key": "aws:Resource",
          "values": {
            "items": [
              {
                "value": "license-configuration:lic-b.................1"
              }
            ]
          }
        },
        {
          "key": "aws:Type",
          "values": {
            "items": [
              {
                "value": "license-configuration"
              }
            ]
          }
        },
        {
          "key": "aws:Account",
          "values": {
            "items": [
              {
                "value": "7...0"
              }
            ]
          }
        },
        {
          "key": "aws:ARN",
          "values": {
            "items": [
              {
                "value": "arn:aws:license-manager:ap-southeast-2:7...2:license-configuration:lic-b.................1"
              }
            ]
          }
        }
      ]
    }
  }
}
```
The AWS documentation for EC2 IAM Permissions lists `license-configuration` as a required resource type for the `StartInstances` action.  - https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonec2.html#amazonec2-resources-for-iam-policies


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
