### PR TITLE
Handled the scenario where the cli throws an error when called withou…

### DIFF
--- a/source/cli/scheduler_cli/scheduler_cli.py
+++ b/source/cli/scheduler_cli/scheduler_cli.py
@@ -299,4 +299,9 @@ def build_parser():
 def main():
     parser = build_parser()
     p = parser.parse_args(sys.argv[1:])
-    sys.exit(p.func(p, p.command))
+    try:
+        sys.exit(p.func(p, p.command))
+    except AttributeError as AE:
+        parser.print_help()
+        sys.exit(0)
+


### PR DESCRIPTION
…t any subcommand or argument. This fix will show the help message

*Issue #, if available: #323*

*Description of changes:*
This fixes #323 by showing a helpful error message when no sub commands are passed in

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
