### PR TITLE
Feature/pipeline

### DIFF
--- a/source/package.json
+++ b/source/package.json
@@ -9,9 +9,7 @@
     "build": "tsc",
     "watch": "tsc -w",
     "test": "jest",
-    "cdk": "cdk",
-    "runinstall": "npm install",
-    "versions": "npm -v && node -v"
+    "cdk": "cdk"
   },
   "devDependencies": {
     "@aws-cdk/assert": "^2.59.0",

--- a/tox.ini
+++ b/tox.ini
@@ -21,11 +21,11 @@ commands =
     pytest source/lambda/tests {posargs}
 
 [testenv:cdk]
-allowlist_externals=npm
+allowlist_externals = npm
+change_dir = source
 description = run CDK unit tests
 package = skip
 commands =
-    npm run --prefix source versions
-    npm run --prefix source runinstall
-    npm run --prefix source build
-    npm run --prefix source test -- {posargs}
+    npm install
+    npm run build
+    npm run test -- {posargs}


### PR DESCRIPTION
*Description of changes:*
Use tox change_dir config option to run npm commands directly in /source directory rather than using the highly discourage npm --prefix flag

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
