### PR TITLE
setup github actions to run unit tests

### DIFF
--- a/.github/workflows/unit-test-workflow.yml
+++ b/.github/workflows/unit-test-workflow.yml
@@ -1,0 +1,36 @@
+name: Unit test workflow
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python: ["3.9", "3.10", "3.11"]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: ${{ matrix.os }} ${{ matrix.python }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+          cache: 'pip'
+          cache-dependency-path: 'source/app/pyproject.toml'
+      - name: Install Tox and any other packages
+        run: |
+          pip install --upgrade pip
+          pip install tox
+          pip install tox-gh-actions
+      - name: Cache tox and mypy
+        uses: actions/cache@v3
+        with:
+          path: |
+            .tox
+            .mypy_cache
+          key: ${{ matrix.os }}-${{ matrix.python}}-tox-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('tox.ini') }}-${{ hashFiles('.github/workflows/unit-test-workflow.yml') }}
+      - name: Run Tox
+        run: tox

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,12 @@ env_list =
 minversion = 4.0.13
 package_root = source/app
 
+[gh-actions]
+python =
+    3.9: lambda, cdk
+    3.10: lambda
+    3.11: lambda
+
 [testenv:lambda]
 description = run lambda unit tests
 package = wheel


### PR DESCRIPTION
Add a github workflow that automatically runs unit tests on push/pull-request

The workflow will test the lambda python code using version 3.9, 3.10, and 3.11

This is adapted from the Refreezer project, and the unit tests all appear to run correctly. However, I am not sure if caching .mypy_cache is correct for this project (line 33 of the workflow). 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
