### PR TITLE
add .venv to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ celerybeat-schedule
 .env
 
 # virtualenv
+.venv/
 venv/
 ENV/
 


### PR DESCRIPTION
.venv is a common python virtual env folder, and my local environment constantly trying to stage it is driving me nuts

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
