### PR TITLE
Add synth workflow for cdk nag (step 1)

### DIFF
--- a/.github/workflows/cdk-nag-workflow.yml
+++ b/.github/workflows/cdk-nag-workflow.yml
@@ -1,0 +1,22 @@
+# Workflow that runs unit test
+name: CDK Nag
+
+on: [push, pull_request]
+
+jobs:
+  cdk-nag:
+    name: CDK Nag Check
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [16.x]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: CDK Synth
+        working-directory: source/infrastructure
+        run: |
+          npm ci
+          npx cdk synth


### PR DESCRIPTION
Add a workflow to automatically run cdk synth on push/PR

This is the first step to running CDK nag automatically on all pushes/PRs. The next step is to implement cdk nag into the templates themselves which will be the focus of the next PR


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
