### PR TITLE
move tsc output to /deployment/cdk.dist

### DIFF
--- a/deployment/build-s3-dist.sh
+++ b/deployment/build-s3-dist.sh
@@ -78,10 +78,10 @@ echo "npm install"
 npm install
 
 # Run 'cdk synth' to generate raw solution outputs
-echo "cd "$cdk_source_dir""
+echo "cd $cdk_source_dir"
 cd "$cdk_source_dir"
 echo "node_modules/aws-cdk/bin/cdk synth --output=$staging_dist_dir"
-npm run build && node_modules/aws-cdk/bin/cdk synth --output=$staging_dist_dir --no-version-reporting
+node_modules/aws-cdk/bin/cdk synth --output=$staging_dist_dir --no-version-reporting
 
 # Remove unnecessary output files
 echo "cd $staging_dist_dir"

--- a/source/infrastructure/tsconfig.json
+++ b/source/infrastructure/tsconfig.json
@@ -22,7 +22,9 @@
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
     "stripInternal": true,
-    "target": "ES2018"
+    "target": "ES2022",
+    "allowJs" : false,
+    "outDir" : "../../deployment/cdk.dist",
   },
   "include": [
     "**/*.ts"


### PR DESCRIPTION
I thought this was going to be harder...

Moving typescript build output to separate folder to prevent hidden build files overriding cdk commands run from cli during development

also updated the target ES version to 2022 since I was in the file anyway.

Tested by running build-s3-dist.sh locally to confirm that all output appear normal.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
