### PR TITLE
Add USER env var to cdk tox env to fix build on MacOS

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -50,6 +50,8 @@ allowlist_externals = npm
 change_dir = source/infrastructure
 description = run CDK unit tests
 package = skip
+pass_env =
+    USER
 commands =
     npm install
     npm run test -- {posargs}


### PR DESCRIPTION
- fixes cdk build on macOS

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
