### PR TITLE
Remove pytest config

### DIFF
--- a/source/app/tests/pytest.ini
+++ b/source/app/tests/pytest.ini
@@ -1,6 +1,0 @@
-[pytest]
-; addopts = -sv -ra -q 
-addopts = -sv 
-#-p tests.plugins.env_vars
-log_cli = true
-log_level=INFO


### PR DESCRIPTION
- remove pytest config

Justification:
- `-s` flag disables capturing output - observing output should not be needed
- `-v` flag enables verbose output - verbose output should not be needed
- `log_cli` outputs logs to the console - log output should not be needed
- `log_level` - not needed if not logging

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
