### PR TITLE
exclude e2e tests from sonar source directories

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -19,6 +19,7 @@ sonar.sources= \
 sonar.exclusions= \
     **/test/**, \
     **/tests/**, \
+    **/e2e-tests/**, \
     **/jest.config.ts, \
     bin/**, \
     source/app/certifi/**/*, \


### PR DESCRIPTION
[sonarqube's documentation](https://docs.sonarqube.org/9.8/project-administration/narrowing-the-focus/) specifies that tests should be excluded from the source directories and instead included as test directories explicitly. The e2e tests are already specified as a test directory, but were also being included as a source directory causing sonarqube to error when the files were being indexed twice. This change should bring us back into compliance with sonarqube standard practice as well as fix the error in the internal pipeline

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
