### PR TITLE
Remove boto3 region filter

### DIFF
--- a/source/app/schedulers/instance_scheduler.py
+++ b/source/app/schedulers/instance_scheduler.py
@@ -93,7 +93,6 @@ class InstanceScheduler:
         self._service = service
         self._instance_states = None
         self._schedule_metrics = None
-        self._valid_regions = []
         self._sts_client = None
         self._scheduled_instances = []
         self._configuration = None
@@ -106,33 +105,15 @@ class InstanceScheduler:
         self._logger = None
         self._context = None
 
-        partition = "aws"
-        try:
-            partition = boto3.client("sts").get_caller_identity()["Arn"].split(":")[1]
-        except Exception as ex:
-            print(ex)
-
-        # valid regions for service
-        self._valid_regions = boto3.Session().get_available_regions(
-            service.service_name, partition
-        )
-
         self._usage_metrics = {"Started": {}, "Stopped": {}, "Resized": {}}
 
     @property
     def _regions(self):
         if len(self._configuration.regions) > 0:
-            result = []
-            regions = self._configuration.regions
-            for r in regions:
-                if r not in self._valid_regions:
-                    self._logger.error(ERR_INVALID_REGION, r)
-                else:
-                    result.append(r)
-            return result
-
-        # no regions, use region of lambda function
-        return [boto3.Session().region_name]
+            return self._configuration.regions
+        else:
+            # no regions, use region of lambda function
+            return [boto3.Session().region_name]
 
     @property
     def _sts(self):


### PR DESCRIPTION
Remove boto3 get_available_regions call that was being used to filter configuration input against a list of valid regions.

By its own documentation, this call is not an exhaustive list of all available regions, and as such we cannot use it as a reliable filter for whether a region exists or not.

Removing this filter ensures that a region that is not listed by boto3 will still be able to schedule correctly (this is currently known to affect eu-central-2). But it will have the side-effect that if the customer provides an invalid region to the solution configuration, additional scheduling executions will be initialized for the invalid region before they inevitably error out when they attempt to access resources that do not exist. Such an invalid configuration will consume additional resources, but should not have any other adverse impacts upon the solution's operation.

Note: This is a followup to https://github.com/aws-solutions/aws-instance-scheduler/pull/428. Only the last commit contains changes related to this story. The rest are from the other PR

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
